### PR TITLE
Refactor serialisation or static include + excludes

### DIFF
--- a/lib/vanilli/server.rb
+++ b/lib/vanilli/server.rb
@@ -1,4 +1,5 @@
 require 'rest-client'
+require 'json'
 
 # Provides hooks for starting and stopping a vanilli server. Relies on the vanilli CLI
 # API and therefore requires vanilli to be installed.
@@ -6,8 +7,8 @@ class VanilliServer
   def initialize(port:, static_root: nil, static_include: [], static_exclude: [], static_default: 'index.html', log_level: 'warn')
     @static_root = static_root
     @static_default = static_default
-    @static_include = static_include.join(',')
-    @static_exclude = static_exclude.join(',')
+    @static_include = JSON.generate(static_include)
+    @static_exclude = JSON.generate(static_exclude)
     @port = port
     @log_level = log_level
   end

--- a/vanilli-ruby.gemspec
+++ b/vanilli-ruby.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rubocop", "~> 0.31"
   spec.add_runtime_dependency "rest-client", "~> 1.8"
+  spec.add_runtime_dependency "json", "~> 1.8"
 end


### PR DESCRIPTION
Now using `json` to generate the strings used for `cli` options. This now allows static includes to take advantage of the following [vanilli update](https://github.com/mixradio/vanilli/pull/31) .