### PR TITLE
kill Vanilli process more reliably on Linux

### DIFF
--- a/lib/vanilli/server.rb
+++ b/lib/vanilli/server.rb
@@ -20,7 +20,8 @@ class VanilliServer
                     --staticRoot=#{@static_root} \
                     --staticDefault=#{@static_default} \
                     --staticInclude='#{@static_include}' \
-                    --staticExclude='#{@static_exclude}'", chdir: cwd)
+                    --staticExclude='#{@static_exclude}'", chdir: cwd, pgroup: true)
+    @pgid = Process.getpgid(@pid)
 
     Timeout.timeout(3) do
       begin
@@ -42,5 +43,9 @@ class VanilliServer
       Process.wait @pid
     end
     @pid = nil
+    if @pgid
+        Process.kill('KILL', -(@pgid))
+    end
+    @pgid = nil
   end
 end


### PR DESCRIPTION
This PR allows to kill off the Vanilli process on Linux.

I noticed that on Linux it kills off the process that has been spawned but the actual Vanilli server runs in another process (with a subsequent PID).

So this PR creates a new process group id and sends the kill signal to the group. I left the original kill command in there as well because a quick test on Mac didn't work using the process group. 
There might be something that can be done about this but I don't have a Mac so it's quite painful for me to test...